### PR TITLE
Add Docker image builds and a docker-compose file

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,12 +1,13 @@
-name: Build Binaries
+name: Build and Release
 
 permissions:
   contents: write
+  packages: write
 
 on:
   push:
     tags:
-      - 'v*'
+      - "v*"
   workflow_dispatch:
 
 jobs:
@@ -20,22 +21,22 @@ jobs:
             target: x86_64-unknown-linux-gnu
             artifact_name: sanitizer-bot
             asset_name: sanitizer-bot-linux-x86_64
-          
+
           - os: ubuntu-latest
             target: aarch64-unknown-linux-gnu
             artifact_name: sanitizer-bot
             asset_name: sanitizer-bot-linux-aarch64
-          
+
           - os: macos-latest
             target: x86_64-apple-darwin
             artifact_name: sanitizer-bot
             asset_name: sanitizer-bot-macos-x86_64
-          
+
           - os: macos-latest
             target: aarch64-apple-darwin
             artifact_name: sanitizer-bot
             asset_name: sanitizer-bot-macos-aarch64
-          
+
           - os: windows-latest
             target: x86_64-pc-windows-msvc
             artifact_name: sanitizer-bot.exe
@@ -79,12 +80,61 @@ jobs:
           name: ${{ matrix.asset_name }}
           path: release/${{ matrix.asset_name }}
 
+  docker:
+    name: Build Docker Image
+    needs: build
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/') || github.event_name == 'workflow_dispatch'
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Download Linux artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Only update :latest tag on releases
+        id: tags
+        shell: bash
+        run: |
+          TAGS="ghcr.io/${{ github.repository }}:${{ github.ref_name }}"
+          if [[ "${GITHUB_REF}" == refs/tags/* ]]; then
+            TAGS="${TAGS}\n"ghcr.io/${{ github.repository }}:latest
+          fi
+          echo "tags<<EOF" >> "$GITHUB_OUTPUT"
+          echo -e "$TAGS" >> "$GITHUB_OUTPUT"
+          echo "EOF" >> "$GITHUB_OUTPUT"
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: Dockerfile
+          push: true
+          platforms: linux/amd64,linux/arm64
+          tags: ${{ steps.tags.outputs.tags }}
+
   release:
     name: Create Release
     needs: build
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/') || github.event_name == 'workflow_dispatch'
-    
+
     steps:
       - uses: actions/checkout@v4
 
@@ -96,7 +146,7 @@ jobs:
       - name: Create release
         uses: softprops/action-gh-release@v1
         with:
-          files: artifacts/*/* 
+          files: artifacts/*/*
           generate_release_notes: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 
 .DS_Store
 .env
+stack.env
 
 local.db
 local.db-*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+FROM debian:bookworm-slim AS bin
+ARG TARGETARCH
+WORKDIR /out
+COPY artifacts/sanitizer-bot-linux-x86_64/sanitizer-bot-linux-x86_64 /tmp/sanitizer-bot-linux-x86_64
+COPY artifacts/sanitizer-bot-linux-aarch64/sanitizer-bot-linux-aarch64 /tmp/sanitizer-bot-linux-aarch64
+RUN chmod +x /tmp/sanitizer-bot-linux-*
+RUN if [ "${TARGETARCH}" = "amd64" ]; then \
+	cp /tmp/sanitizer-bot-linux-x86_64 /out/sanitizer-bot; \
+	else \
+	cp /tmp/sanitizer-bot-linux-aarch64 /out/sanitizer-bot; \
+	fi
+
+FROM gcr.io/distroless/cc-debian12
+WORKDIR /data
+COPY --from=bin /out/sanitizer-bot /app/sanitizer-bot
+ENV SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt
+VOLUME ["/data"]
+ENTRYPOINT ["/app/sanitizer-bot"]

--- a/README.md
+++ b/README.md
@@ -34,6 +34,25 @@ To host your own instance of the bot on Shuttle, follow along. This project is n
 
 3. Run the binary.
 
+### Docker
+
+Sanitizer can also be run using Docker. Prebuilt, lightweight images are published to GitHub Container Registry (GHCR) on each release.
+
+Image:
+`ghcr.io/suhaybu/sanitizer-bot`
+
+The container uses the same environment variables as the binary:
+DISCORD_TOKEN, TURSO_DATABASE_URL, TURSO_AUTH_TOKEN, EMOJI_ID
+
+When running in Docker, Sanitizer uses Turso’s embedded replica mode. This creates a local SQLite database file inside the container that must be persisted with a volume mount so server configuration and message mappings survive restarts.
+
+A sample docker-compose.yml is provided in the repository for reference. Note that the example docker-compose.yml references the `stack.env` file used within Portainer. You can modify this to use your own `.env` file or set the variables directly in the docker-compose.yml if you wish.
+
+To update the bot:
+- Pull the latest image from GHCR
+- Restart the container
+
+
 ## Usage
 
 Once the bot is running, you can use the following commands:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,11 @@
+services:
+    sanitizer-bot:
+        image: ghcr.io/suhaybu/sanitizer-bot:latest
+        restart: unless-stopped
+        env_file:
+            - stack.env # This will load the env values set in Buape's panel
+        volumes:
+            - sanitizer_data:/data
+
+volumes:
+    sanitizer_data:


### PR DESCRIPTION
This builds on top of your existing Github Actions release setup to generate the binaries using the same tags setup that you do for releases currently.

### Changes
  - Add a Docker build-and-push job that publishes multi-arch images to GHCR on each release, using the binaries you already build in Github Actions
  - Add Dockerfile to use a lightweight distroless runtime, generated in the github actions with the artifacts that the release uses
  - Added a docker-compose.yml 
  - Added Docker info to the README

